### PR TITLE
refactor: closes ResultSet to avoid Memory Leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changes
+
+- Fixed ResultSet instances to avoid Memory Leaks
 
 ## [1.12.0] - 2022-01-14
 

--- a/src/main/java/io/supertokens/storage/mysql/queries/EmailPasswordQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/EmailPasswordQueries.java
@@ -108,16 +108,17 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
-            ResultSet result = pst.executeQuery();
-            List<PasswordResetTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordResetTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -129,16 +130,17 @@ public class EmailPasswordQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
-            ResultSet result = pst.executeQuery();
-            List<PasswordResetTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordResetTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -149,9 +151,10 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, token);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -274,9 +277,10 @@ public class EmailPasswordQueries {
                     // i+1 cause this starts with 1 and not 0
                     pst.setString(i + 1, ids.get(i));
                 }
-                ResultSet result = pst.executeQuery();
-                while (result.next()) {
-                    finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                try (ResultSet result = pst.executeQuery()) {
+                    while (result.next()) {
+                        finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                    }
                 }
             }
         }
@@ -289,9 +293,10 @@ public class EmailPasswordQueries {
                 + Config.getConfig(start).getEmailPasswordUsersTable() + " WHERE user_id = ? FOR UPDATE";
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, id);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -303,9 +308,10 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, email);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -320,16 +326,17 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setInt(1, limit);
-            ResultSet result = pst.executeQuery();
-            List<UserInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<UserInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                UserInfo[] finalResult = new UserInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            UserInfo[] finalResult = new UserInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -347,16 +354,17 @@ public class EmailPasswordQueries {
             pst.setLong(2, timeJoined);
             pst.setString(3, userId);
             pst.setInt(4, limit);
-            ResultSet result = pst.executeQuery();
-            List<UserInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<UserInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                UserInfo[] finalResult = new UserInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            UserInfo[] finalResult = new UserInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -365,11 +373,12 @@ public class EmailPasswordQueries {
         String QUERY = "SELECT COUNT(*) as total FROM " + Config.getConfig(start).getEmailPasswordUsersTable();
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getLong("total");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getLong("total");
+                }
+                return 0;
             }
-            return 0;
         }
     }
 

--- a/src/main/java/io/supertokens/storage/mysql/queries/EmailVerificationQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/EmailVerificationQueries.java
@@ -105,9 +105,10 @@ public class EmailVerificationQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, token);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -138,16 +139,17 @@ public class EmailVerificationQueries {
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
             pst.setString(2, email);
-            ResultSet result = pst.executeQuery();
-            List<EmailVerificationTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<EmailVerificationTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -160,16 +162,17 @@ public class EmailVerificationQueries {
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
             pst.setString(2, email);
-            ResultSet result = pst.executeQuery();
-            List<EmailVerificationTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<EmailVerificationTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -182,9 +185,9 @@ public class EmailVerificationQueries {
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
             pst.setString(2, email);
-            ResultSet result = pst.executeQuery();
-
-            return result.next();
+            try (ResultSet result = pst.executeQuery()) {
+                return result.next();
+            }
         }
     }
 

--- a/src/main/java/io/supertokens/storage/mysql/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/GeneralQueries.java
@@ -250,9 +250,10 @@ public class GeneralQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, key);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -265,9 +266,10 @@ public class GeneralQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, key);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -313,11 +315,12 @@ public class GeneralQueries {
 
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY.toString())) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getLong("total");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getLong("total");
+                }
+                return 0;
             }
-            return 0;
         }
     }
 
@@ -343,7 +346,6 @@ public class GeneralQueries {
                 RECIPE_ID_CONDITION.append(")");
             }
 
-            ResultSet result;
             if (timeJoined != null && userId != null) {
                 String recipeIdCondition = RECIPE_ID_CONDITION.toString();
                 if (!recipeIdCondition.equals("")) {
@@ -360,10 +362,11 @@ public class GeneralQueries {
                     pst.setLong(2, timeJoined);
                     pst.setString(3, userId);
                     pst.setInt(4, limit);
-                    result = pst.executeQuery();
-                    while (result.next()) {
-                        usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
-                                result.getString("recipe_id")));
+                    try (ResultSet result = pst.executeQuery()) {
+                        while (result.next()) {
+                            usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
+                                    result.getString("recipe_id")));
+                        }
                     }
                 }
             } else {
@@ -376,10 +379,11 @@ public class GeneralQueries {
                 try (Connection con = ConnectionPool.getConnection(start);
                         PreparedStatement pst = con.prepareStatement(QUERY)) {
                     pst.setInt(1, limit);
-                    result = pst.executeQuery();
-                    while (result.next()) {
-                        usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
-                                result.getString("recipe_id")));
+                    try (ResultSet result = pst.executeQuery()) {
+                        while (result.next()) {
+                            usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
+                                    result.getString("recipe_id")));
+                        }
                     }
                 }
             }

--- a/src/main/java/io/supertokens/storage/mysql/queries/JWTSigningQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/JWTSigningQueries.java
@@ -51,14 +51,15 @@ public class JWTSigningQueries {
                 + " ORDER BY created_at DESC FOR UPDATE";
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            List<JWTSigningKeyInfo> keys = new ArrayList<>();
+            try (ResultSet result = pst.executeQuery()) {
+                List<JWTSigningKeyInfo> keys = new ArrayList<>();
 
-            while (result.next()) {
-                keys.add(JWTSigningKeyInfoRowMapper.getInstance().mapOrThrow(result));
+                while (result.next()) {
+                    keys.add(JWTSigningKeyInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+
+                return keys;
             }
-
-            return keys;
         }
     }
 

--- a/src/main/java/io/supertokens/storage/mysql/queries/PasswordlessQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/PasswordlessQueries.java
@@ -108,9 +108,10 @@ public class PasswordlessQueries {
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, deviceIdHash);
 
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -194,16 +195,17 @@ public class PasswordlessQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, deviceIdHash);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessCode> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessCode> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -215,9 +217,10 @@ public class PasswordlessQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, linkCodeHash);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -344,10 +347,10 @@ public class PasswordlessQueries {
                     + Config.getConfig(start).getPasswordlessDevicesTable() + " WHERE device_id_hash = ?";
             try (PreparedStatement pst = con.prepareStatement(QUERY)) {
                 pst.setString(1, deviceIdHash);
-                ResultSet result = pst.executeQuery();
-
-                if (result.next()) {
-                    return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+                try (ResultSet result = pst.executeQuery()) {
+                    if (result.next()) {
+                        return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+                    }
                 }
             }
             return null;
@@ -362,16 +365,17 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, email);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessDevice> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessDevice> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -383,16 +387,17 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, phoneNumber);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessDevice> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessDevice> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -411,16 +416,17 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setLong(1, time);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessCode> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessCode> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -431,9 +437,10 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, codeId);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -470,9 +477,10 @@ public class PasswordlessQueries {
                     // i+1 cause this starts with 1 and not 0
                     pst.setString(i + 1, ids.get(i));
                 }
-                ResultSet result = pst.executeQuery();
-                while (result.next()) {
-                    finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                try (ResultSet result = pst.executeQuery()) {
+                    while (result.next()) {
+                        finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                    }
                 }
             }
         }
@@ -497,9 +505,10 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, email);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -513,10 +522,10 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, phoneNumber);
-            ResultSet result = pst.executeQuery();
-
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;

--- a/src/main/java/io/supertokens/storage/mysql/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/SessionQueries.java
@@ -76,10 +76,10 @@ public class SessionQueries {
                 + " WHERE session_handle = ? FOR UPDATE";
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, sessionHandle);
-            ResultSet result = pst.executeQuery();
-
-            if (result.next()) {
-                return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -103,11 +103,12 @@ public class SessionQueries {
 
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getInt("num");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getInt("num");
+                }
+                throw new SQLException("Should not have come here.");
             }
-            throw new SQLException("Should not have come here.");
         }
     }
 
@@ -151,16 +152,17 @@ public class SessionQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
-            ResultSet result = pst.executeQuery();
-            List<String> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(result.getString("session_handle"));
+            try (ResultSet result = pst.executeQuery()) {
+                List<String> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(result.getString("session_handle"));
+                }
+                String[] finalResult = new String[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            String[] finalResult = new String[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -181,9 +183,10 @@ public class SessionQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, sessionHandle);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -240,16 +243,17 @@ public class SessionQueries {
         String QUERY = "SELECT * FROM " + Config.getConfig(start).getAccessTokenSigningKeysTable() + " FOR UPDATE";
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            List<KeyValueInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(AccessTokenSigningKeyRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<KeyValueInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(AccessTokenSigningKeyRowMapper.getInstance().mapOrThrow(result));
+                }
+                KeyValueInfo[] finalResult = new KeyValueInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            KeyValueInfo[] finalResult = new KeyValueInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 

--- a/src/main/java/io/supertokens/storage/mysql/queries/ThirdPartyQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/ThirdPartyQueries.java
@@ -147,9 +147,10 @@ public class ThirdPartyQueries {
                     // i+1 cause this starts with 1 and not 0
                     pst.setString(i + 1, ids.get(i));
                 }
-                ResultSet result = pst.executeQuery();
-                while (result.next()) {
-                    finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                try (ResultSet result = pst.executeQuery()) {
+                    while (result.next()) {
+                        finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                    }
                 }
             }
         }
@@ -166,9 +167,10 @@ public class ThirdPartyQueries {
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, thirdPartyId);
             pst.setString(2, thirdPartyUserId);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -196,9 +198,10 @@ public class ThirdPartyQueries {
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, thirdPartyId);
             pst.setString(2, thirdPartyUserId);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -236,16 +239,17 @@ public class ThirdPartyQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setInt(1, limit);
-            ResultSet result = pst.executeQuery();
-            List<UserInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<UserInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                UserInfo[] finalResult = new UserInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            UserInfo[] finalResult = new UserInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -263,16 +267,17 @@ public class ThirdPartyQueries {
             pst.setLong(2, timeJoined);
             pst.setString(3, userId);
             pst.setInt(4, limit);
-            ResultSet result = pst.executeQuery();
-            List<UserInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<UserInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                UserInfo[] finalResult = new UserInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            UserInfo[] finalResult = new UserInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -281,11 +286,12 @@ public class ThirdPartyQueries {
         String QUERY = "SELECT COUNT(*) as total FROM " + Config.getConfig(start).getThirdPartyUsersTable();
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getLong("total");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getLong("total");
+                }
+                return 0;
             }
-            return 0;
         }
     }
 


### PR DESCRIPTION
## Summary of change
Closes The ResultSet object by wrapping then in a try-with-resources block

## Related issues
- https://github.com/supertokens/supertokens-core/issues/361

## Test Plan
NA

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
