### PR TITLE
fixes: Takes into account StorageTransactionLogicException when doing retries in transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.12.1] - 2022-02-16
+
+- Fixed https://github.com/supertokens/supertokens-core/issues/373: Catching `StorageTransactionLogicException` in
+  transaction helper function for retries
 - add workflow to verify if pr title follows conventional commits
 
 ## [1.12.0] - 2022-01-14
@@ -21,12 +25,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Delete user functionality
 
-
 ## [1.10.0] - 2021-09-10
 
 ### Changed
 
-- Updated to match 2.9 plugin interface to support multiple access token signing keys: https://github.com/supertokens/supertokens-core/issues/305
+- Updated to match 2.9 plugin interface to support multiple access token signing
+  keys: https://github.com/supertokens/supertokens-core/issues/305
 - Added functions and other changes for the JWT recipe
 
 ## [1.9.0] - 2021-06-20

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "1.12.0"
+version = "1.12.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/storage/mysql/Start.java
+++ b/src/main/java/io/supertokens/storage/mysql/Start.java
@@ -158,7 +158,7 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
             tries++;
             try {
                 return startTransactionHelper(logic);
-            } catch (SQLException | StorageQueryException e) {
+            } catch (SQLException | StorageQueryException | StorageTransactionLogicException e) {
                 // check according to: https://github.com/supertokens/supertokens-mysql-plugin/pull/2
                 if ((e instanceof SQLTransactionRollbackException || e.getMessage().toLowerCase().contains("deadlock"))
                         && tries < 3) {
@@ -171,6 +171,8 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
                 }
                 if (e instanceof StorageQueryException) {
                     throw (StorageQueryException) e;
+                } else if (e instanceof StorageTransactionLogicException) {
+                    throw (StorageTransactionLogicException) e;
                 }
                 throw new StorageQueryException(e);
             }


### PR DESCRIPTION
## Summary of change
- Catching `StorageTransactionLogicException` in transaction helper function for retries.
- Added a new test in PostgreSQL plugin which uses passwordless recipe to simulate a deadlock which should be retried

## Related issues
- https://github.com/supertokens/supertokens-core/issues/373

## Test Plan
- Added a new test

## Documentation changes
None

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.