### PR TITLE
feat: use lower isolation level for pwless createDeviceWithCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.0] - 2022-02-23
+
+### Changed
+
+- Using lower transaction isolation level while creating passwordless device with code
+
 ## [1.12.1] - 2022-02-16
 
 - Fixed https://github.com/supertokens/supertokens-core/issues/373: Catching `StorageTransactionLogicException` in

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "1.12.1"
+version = "1.13.0"
 
 repositories {
     mavenCentral()

--- a/pluginInterfaceSupported.json
+++ b/pluginInterfaceSupported.json
@@ -1,6 +1,6 @@
 {
   "_comment": "contains a list of plugin interfaces branch names that this core supports",
   "versions": [
-    "2.11"
+    "2.12"
   ]
 }

--- a/src/main/java/io/supertokens/storage/mysql/Start.java
+++ b/src/main/java/io/supertokens/storage/mysql/Start.java
@@ -153,17 +153,17 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
     @Override
     public <T> T startTransaction(TransactionLogic<T> logic)
             throws StorageTransactionLogicException, StorageQueryException {
-        return startTransaction(logic, true);
+        return startTransaction(logic, TransactionIsolationLevel.SERIALIZABLE);
     }
 
     @Override
-    public <T> T startTransaction(TransactionLogic<T> logic, boolean serializableIsolation)
+    public <T> T startTransaction(TransactionLogic<T> logic, TransactionIsolationLevel isolationLevel)
             throws StorageTransactionLogicException, StorageQueryException {
         int tries = 0;
         while (true) {
             tries++;
             try {
-                return startTransactionHelper(logic, serializableIsolation);
+                return startTransactionHelper(logic, isolationLevel);
             } catch (SQLException | StorageQueryException | StorageTransactionLogicException e) {
                 // check according to: https://github.com/supertokens/supertokens-mysql-plugin/pull/2
                 if ((e instanceof SQLTransactionRollbackException
@@ -186,15 +186,16 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
         }
     }
 
-    private <T> T startTransactionHelper(TransactionLogic<T> logic, boolean serializableIsolation)
+    private <T> T startTransactionHelper(TransactionLogic<T> logic, TransactionIsolationLevel isolationLevel)
             throws StorageQueryException, StorageTransactionLogicException, SQLException {
         Connection con = null;
         Integer defaultTransactionIsolation = null;
         try {
             con = ConnectionPool.getConnection(this);
             defaultTransactionIsolation = con.getTransactionIsolation();
-            con.setTransactionIsolation(serializableIsolation ? Connection.TRANSACTION_SERIALIZABLE
-                    : Connection.TRANSACTION_REPEATABLE_READ);
+            con.setTransactionIsolation(
+                    isolationLevel == TransactionIsolationLevel.SERIALIZABLE ? Connection.TRANSACTION_SERIALIZABLE
+                            : Connection.TRANSACTION_REPEATABLE_READ);
             con.setAutoCommit(false);
             return logic.mainLogicAndCommit(new TransactionConnection(con));
         } catch (Exception e) {

--- a/src/main/java/io/supertokens/storage/mysql/Start.java
+++ b/src/main/java/io/supertokens/storage/mysql/Start.java
@@ -193,9 +193,20 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
         try {
             con = ConnectionPool.getConnection(this);
             defaultTransactionIsolation = con.getTransactionIsolation();
-            con.setTransactionIsolation(
-                    isolationLevel == TransactionIsolationLevel.SERIALIZABLE ? Connection.TRANSACTION_SERIALIZABLE
-                            : Connection.TRANSACTION_REPEATABLE_READ);
+            int libIsolationLevel = Connection.TRANSACTION_SERIALIZABLE;
+            switch (isolationLevel) {
+            case SERIALIZABLE:
+                libIsolationLevel = Connection.TRANSACTION_SERIALIZABLE;
+            case REPEATABLE_READ:
+                libIsolationLevel = Connection.TRANSACTION_REPEATABLE_READ;
+            case READ_COMMITTED:
+                libIsolationLevel = Connection.TRANSACTION_READ_COMMITTED;
+            case READ_UNCOMMITTED:
+                libIsolationLevel = Connection.TRANSACTION_READ_UNCOMMITTED;
+            case NONE:
+                libIsolationLevel = Connection.TRANSACTION_NONE;
+            }
+            con.setTransactionIsolation(libIsolationLevel);
             con.setAutoCommit(false);
             return logic.mainLogicAndCommit(new TransactionConnection(con));
         } catch (Exception e) {

--- a/src/main/java/io/supertokens/storage/mysql/queries/PasswordlessQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/PasswordlessQueries.java
@@ -28,6 +28,7 @@ import io.supertokens.pluginInterface.passwordless.PasswordlessCode;
 import io.supertokens.pluginInterface.passwordless.PasswordlessDevice;
 import io.supertokens.pluginInterface.passwordless.UserInfo;
 import io.supertokens.pluginInterface.passwordless.exception.UnknownDeviceIdHash;
+import io.supertokens.pluginInterface.sqlStorage.SQLStorage.TransactionIsolationLevel;
 
 import javax.annotation.Nonnull;
 import java.sql.Connection;
@@ -97,7 +98,7 @@ public class PasswordlessQueries {
                 throw new StorageTransactionLogicException(throwables);
             }
             return null;
-        }, false);
+        }, TransactionIsolationLevel.REPEATABLE_READ);
     }
 
     public static PasswordlessDevice getDevice_Transaction(Start start, Connection con, String deviceIdHash)

--- a/src/main/java/io/supertokens/storage/mysql/queries/PasswordlessQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/PasswordlessQueries.java
@@ -97,7 +97,7 @@ public class PasswordlessQueries {
                 throw new StorageTransactionLogicException(throwables);
             }
             return null;
-        });
+        }, false);
     }
 
     public static PasswordlessDevice getDevice_Transaction(Start start, Connection con, String deviceIdHash)


### PR DESCRIPTION
## Summary of change
Updated for new plugin interface and use lower transaction isolation level for createDeviceWithCode

## Related issues
- https://github.com/supertokens/supertokens-plugin-interface/pull/30

## Test Plan
Added test to check that createDeviceWithCode doesn't deadlock

## Documentation changes

N/A

## Checklist for important updates
- [x] Changelog has been updated
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
