### PR TITLE
Fixes issue with memory leak during testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fixes issue https://github.com/supertokens/supertokens-mysql-plugin/issues/31
 
 ## [1.13.0] - 2022-02-23
 

--- a/src/main/java/io/supertokens/storage/mysql/ConnectionPool.java
+++ b/src/main/java/io/supertokens/storage/mysql/ConnectionPool.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 public class ConnectionPool extends ResourceDistributor.SingletonResource {
 
     private static final String RESOURCE_KEY = "io.supertokens.storage.mysql.ConnectionPool";
-    private final HikariDataSource ds;
+    private static HikariDataSource hikariDataSource = null;
 
     private ConnectionPool(Start start) {
         if (!start.enabled) {
@@ -79,7 +79,7 @@ public class ConnectionPool extends ResourceDistributor.SingletonResource {
         // - Failed to validate connection org.mariadb.jdbc.MariaDbConnection@79af83ae (Connection.setNetworkTimeout
         // cannot be called on a closed connection). Possibly consider using a shorter maxLifetime value.
         config.setPoolName("SuperTokens");
-        ds = new HikariDataSource(config);
+        hikariDataSource = new HikariDataSource(config);
     }
 
     private static int getTimeToWaitToInit(Start start) {
@@ -163,13 +163,14 @@ public class ConnectionPool extends ResourceDistributor.SingletonResource {
         if (!start.enabled) {
             throw new SQLException("Storage layer disabled");
         }
-        return getInstance(start).ds.getConnection();
+        return ConnectionPool.hikariDataSource.getConnection();
     }
 
     public static void close(Start start) {
         if (getInstance(start) == null) {
             return;
         }
-        getInstance(start).ds.close();
+        ConnectionPool.hikariDataSource.close();
+        ConnectionPool.hikariDataSource = null;
     }
 }

--- a/src/main/java/io/supertokens/storage/mysql/output/CustomLayout.java
+++ b/src/main/java/io/supertokens/storage/mysql/output/CustomLayout.java
@@ -28,11 +28,11 @@ import java.util.Date;
 
 class CustomLayout extends LayoutBase<ILoggingEvent> {
 
-    private final Start start;
+    private final String processID;
 
-    CustomLayout(Start start) {
+    CustomLayout(String processID) {
         super();
-        this.start = start;
+        this.processID = processID;
     }
 
     @Override
@@ -47,7 +47,7 @@ class CustomLayout extends LayoutBase<ILoggingEvent> {
         sbuf.append(" | ");
 
         sbuf.append("pid: ");
-        sbuf.append(start.getProcessId());
+        sbuf.append(this.processID);
         sbuf.append(" | ");
 
         sbuf.append("[");

--- a/src/main/java/io/supertokens/storage/mysql/output/LayoutWrappingEncoder.java
+++ b/src/main/java/io/supertokens/storage/mysql/output/LayoutWrappingEncoder.java
@@ -28,8 +28,8 @@ class LayoutWrappingEncoder extends EncoderBase<ILoggingEvent> {
 
     private Layout<ILoggingEvent> layout;
 
-    LayoutWrappingEncoder(Start start) {
-        layout = new CustomLayout(start);
+    LayoutWrappingEncoder(String processID) {
+        layout = new CustomLayout(processID);
     }
 
     @Override

--- a/src/main/java/io/supertokens/storage/mysql/output/Logging.java
+++ b/src/main/java/io/supertokens/storage/mysql/output/Logging.java
@@ -35,12 +35,11 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logging(Start start, String infoLogPath, String errorLogPath) {
         this.infoLogger = infoLogPath.equals("null")
-                ? createLoggerForConsole(start, "io.supertokens.storage.mysql.Info." + start.getProcessId())
-                : createLoggerForFile(start, infoLogPath, "io.supertokens.storage.mysql.Info." + start.getProcessId());
+                ? createLoggerForConsole(start, "io.supertokens.storage.mysql.Info")
+                : createLoggerForFile(start, infoLogPath, "io.supertokens.storage.mysql.Info");
         this.errorLogger = errorLogPath.equals("null")
-                ? createLoggerForConsole(start, "io.supertokens.storage.mysql.Error." + start.getProcessId())
-                : createLoggerForFile(start, errorLogPath,
-                        "io.supertokens.storage.mysql.Error." + start.getProcessId());
+                ? createLoggerForConsole(start, "io.supertokens.storage.mysql.Error")
+                : createLoggerForFile(start, errorLogPath, "io.supertokens.storage.mysql.Error");
     }
 
     private static Logging getInstance(Start start) {
@@ -139,7 +138,7 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logger createLoggerForFile(Start start, String file, String name) {
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(start);
+        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(start.getProcessId());
         ple.setContext(lc);
         ple.start();
         FileAppender<ILoggingEvent> fileAppender = new FileAppender<>();
@@ -157,7 +156,7 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logger createLoggerForConsole(Start start, String name) {
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(start);
+        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(start.getProcessId());
         ple.setContext(lc);
         ple.start();
         ConsoleAppender<ILoggingEvent> logConsoleAppender = new ConsoleAppender<>();

--- a/src/test/java/io/supertokens/storage/mysql/test/DeadlockTest.java
+++ b/src/test/java/io/supertokens/storage/mysql/test/DeadlockTest.java
@@ -159,7 +159,7 @@ public class DeadlockTest {
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 
-        ExecutorService es = Executors.newCachedThreadPool();
+        ExecutorService es = Executors.newFixedThreadPool(1000);
 
         AtomicBoolean pass = new AtomicBoolean(true);
 
@@ -195,7 +195,7 @@ public class DeadlockTest {
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 
-        ExecutorService es = Executors.newCachedThreadPool();
+        ExecutorService es = Executors.newFixedThreadPool(1000);
 
         AtomicBoolean pass = new AtomicBoolean(true);
 

--- a/src/test/java/io/supertokens/storage/mysql/test/InMemoryDBTest.java
+++ b/src/test/java/io/supertokens/storage/mysql/test/InMemoryDBTest.java
@@ -92,6 +92,7 @@ public class InMemoryDBTest {
 
         {
             String[] args = { "../" };
+            StorageLayer.close();
             TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
             assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 

--- a/src/test/java/io/supertokens/storage/mysql/test/LoggingTest.java
+++ b/src/test/java/io/supertokens/storage/mysql/test/LoggingTest.java
@@ -54,6 +54,7 @@ public class LoggingTest {
 
     @Test
     public void defaultLogging() throws Exception {
+        StorageLayer.close();
         String[] args = { "../" };
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
 
@@ -148,15 +149,16 @@ public class LoggingTest {
 
     @Test
     public void confirmLoggerClosed() throws Exception {
+        StorageLayer.close();
         String[] args = { "../" };
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
 
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 
         ch.qos.logback.classic.Logger mysqlInfo = (ch.qos.logback.classic.Logger) LoggerFactory
-                .getLogger("io.supertokens.storage.mysql.Info." + process.getProcess().getProcessId());
+                .getLogger("io.supertokens.storage.mysql.Info");
         ch.qos.logback.classic.Logger mysqlError = (ch.qos.logback.classic.Logger) LoggerFactory
-                .getLogger("io.supertokens.storage.mysql.Error." + process.getProcess().getProcessId());
+                .getLogger("io.supertokens.storage.mysql.Error");
 
         ch.qos.logback.classic.Logger hikariLogger = (Logger) LoggerFactory.getLogger("com.zaxxer.hikari");
 

--- a/src/test/java/io/supertokens/storage/mysql/test/TableCreationTest.java
+++ b/src/test/java/io/supertokens/storage/mysql/test/TableCreationTest.java
@@ -18,6 +18,7 @@
 package io.supertokens.storage.mysql.test;
 
 import io.supertokens.ProcessState;
+import io.supertokens.storageLayer.StorageLayer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,6 +56,7 @@ public class TableCreationTest {
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
 
+        StorageLayer.close();
         process = TestingProcessManager.start(args);
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 


### PR DESCRIPTION
## Summary of change
There were a few memery leaks in the core during testing and some of them were related to how we setup loggers and connection to the storage layer. So to fix that, we had to make some changes to this plugin.

## Related issues
- https://github.com/supertokens/supertokens-mysql-plugin/issues/31


## Documentation changes
None

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
