### PR TITLE
feat: adds support for user migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [2.0.0] - 2022-09-19
 
-- Updates the `third_party_user_id` column in the `thirdparty_users` table from `VARCHAR(128)` to `VARCHAR(255)` to resolve https://github.com/supertokens/supertokens-core/issues/306
-  - For legacy users run `ALTER TABLE thirdparty_users MODIFY third_party_user_id VARCHAR(255);` to update your database with the change.
+- Updates the `third_party_user_id` column in the `thirdparty_users` table from `VARCHAR(128)` to `VARCHAR(256)` to resolve https://github.com/supertokens/supertokens-core/issues/306
 
 - Adds support for user migration
-  - Updates the `password_hash` column in the `emailpassword_users` table from `VARCHAR(128)` to `VARCHAR(255)` to support more types of password hashes.
+  - Updates the `password_hash` column in the `emailpassword_users` table from `VARCHAR(128)` to `VARCHAR(256)` to support more types of password hashes.
 
 - For legacy users who are self hosting the SuperTokens core run the following command to update your database with the changes:
-`ALTER TABLE thirdparty_users MODIFY third_party_user_id VARCHAR(255); ALTER TABLE emailpassword_users MODIFY password_hash VARCHAR(255);` 
+`ALTER TABLE thirdparty_users MODIFY third_party_user_id VARCHAR(256); ALTER TABLE emailpassword_users MODIFY password_hash VARCHAR(256);` 
 
 ## [1.19.0] - 2022-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.0.0] - 2022-09-19
+
+- Updates the `third_party_user_id` column in the `thirdparty_users` table from `VARCHAR(128)` to `VARCHAR(255)` to resolve https://github.com/supertokens/supertokens-core/issues/306
+  - For legacy users run `ALTER TABLE thirdparty_users MODIFY third_party_user_id VARCHAR(255);` to update your database with the change.
+
+- Adds support for user migration
+  - Updates the `password_hash` column in the `emailpassword_users` table from `VARCHAR(128)` to `VARCHAR(255)` to support more types of password hashes.
+
+- For legacy users who are self hosting the SuperTokens core run the following command to update your database with the changes:
+`ALTER TABLE thirdparty_users MODIFY third_party_user_id VARCHAR(255); ALTER TABLE emailpassword_users MODIFY password_hash VARCHAR(255);` 
+
 ## [1.19.0] - 2022-08-18
 
 - Adds log level feature and compatibility with plugin interface 2.18

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "1.19.0"
+version = "2.0.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/storage/mysql/queries/EmailPasswordQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/EmailPasswordQueries.java
@@ -42,7 +42,7 @@ public class EmailPasswordQueries {
     static String getQueryToCreateUsersTable(Start start) {
         return "CREATE TABLE IF NOT EXISTS " + getConfig(start).getEmailPasswordUsersTable() + " ("
                 + "user_id CHAR(36) NOT NULL," + "email VARCHAR(256) NOT NULL UNIQUE,"
-                + "password_hash VARCHAR(128) NOT NULL," + "time_joined BIGINT UNSIGNED NOT NULL,"
+                + "password_hash VARCHAR(256) NOT NULL," + "time_joined BIGINT UNSIGNED NOT NULL,"
                 + "PRIMARY KEY (user_id));";
     }
 

--- a/src/main/java/io/supertokens/storage/mysql/queries/ThirdPartyQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/ThirdPartyQueries.java
@@ -40,7 +40,7 @@ public class ThirdPartyQueries {
 
     static String getQueryToCreateUsersTable(Start start) {
         return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getThirdPartyUsersTable() + " ("
-                + "third_party_id VARCHAR(28) NOT NULL," + "third_party_user_id VARCHAR(255) NOT NULL,"
+                + "third_party_id VARCHAR(28) NOT NULL," + "third_party_user_id VARCHAR(256) NOT NULL,"
                 + "user_id CHAR(36) NOT NULL UNIQUE," + "email VARCHAR(256) NOT NULL,"
                 + "time_joined BIGINT UNSIGNED NOT NULL," + "PRIMARY KEY (third_party_id, third_party_user_id));";
     }

--- a/src/main/java/io/supertokens/storage/mysql/queries/ThirdPartyQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/ThirdPartyQueries.java
@@ -40,7 +40,7 @@ public class ThirdPartyQueries {
 
     static String getQueryToCreateUsersTable(Start start) {
         return "CREATE TABLE IF NOT EXISTS " + Config.getConfig(start).getThirdPartyUsersTable() + " ("
-                + "third_party_id VARCHAR(28) NOT NULL," + "third_party_user_id VARCHAR(128) NOT NULL,"
+                + "third_party_id VARCHAR(28) NOT NULL," + "third_party_user_id VARCHAR(255) NOT NULL,"
                 + "user_id CHAR(36) NOT NULL UNIQUE," + "email VARCHAR(256) NOT NULL,"
                 + "time_joined BIGINT UNSIGNED NOT NULL," + "PRIMARY KEY (third_party_id, third_party_user_id));";
     }


### PR DESCRIPTION
## Summary of change
- Updates the `password_hash` column from `VARCHAR(128)` to `VARCHAR(256)` in the `emailpassword_users` table.
- Updates the `third_party_user_id` column from `VARCHAR(128)` to `VARCHAR(255)` in the "thirdparty_users" table.
## Related issues
- https://github.com/supertokens/supertokens-core/pull/507

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- none