### PR TITLE
fix: pass cicd parameters to test runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             mysql -u root --password=root -e "CREATE DATABASE st50;"
       - run:
           name: running tests
-          command: (cd .circleci/ && ./doTests.sh)
+          command: (cd .circleci/ && ./doTests.sh << parameters.plugin >>)
       - store_test_results:
           path: ~/junit
       - slack/status


### PR DESCRIPTION
## Summary of change

(A few sentences about this PR)

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] When adding new recipes, ensure that its performance is being measured in the `OneMillionUsersTest`

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2