### PR TITLE
feat: bulk migration returns user ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [8.1.1]
+
+- Adds more null and empty checks for bulk migration
+
 ## [8.1.0]
 
 - Adds support for webauthn (passkeys)

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "8.1.0"
+version = "8.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/storage/mysql/queries/BulkImportQueries.java
+++ b/src/main/java/io/supertokens/storage/mysql/queries/BulkImportQueries.java
@@ -73,6 +73,9 @@ public class BulkImportQueries {
 
     public static void insertBulkImportUsers_Transaction(Start start, Connection con, AppIdentifier appIdentifier, List<BulkImportUser> users)
             throws SQLException, StorageQueryException {
+        if(users == null || users.isEmpty()){
+            return;
+        }
         String queryBuilder = "INSERT INTO " + Config.getConfig(start).getBulkImportUsersTable() +
                 " (id, app_id, raw_data, created_at, updated_at) VALUES "
                 + " (?, ?, ?, ?, ?)";
@@ -312,6 +315,9 @@ public class BulkImportQueries {
     public static void updateMultipleBulkImportUsersStatusToError_Transaction(Start start, Connection con, AppIdentifier appIdentifier,
                                                                               @Nonnull Map<String,String> bulkImportUserIdToErrorMessage)
             throws SQLException, StorageQueryException {
+        if(bulkImportUserIdToErrorMessage == null || bulkImportUserIdToErrorMessage.isEmpty()){
+            return;
+        }
         BULK_IMPORT_USER_STATUS errorStatus = BULK_IMPORT_USER_STATUS.FAILED;
         String query = "UPDATE " + Config.getConfig(start).getBulkImportUsersTable()
                 + " SET status = ?, error_msg = ?, updated_at = ? WHERE app_id = ? and id = ?";


### PR DESCRIPTION
## Summary of change

Adds support for "bulk migration returns userids" (additional null and empty checks)

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] When adding new recipes, ensure that its performance is being measured in the `OneMillionUsersTest`

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2